### PR TITLE
Fixes #63 removed sourcemap option in css-load

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,6 @@ module.exports = env => {
                 localIdentName: "[path]-[local]--[hash:base64:5]",
                 importLoaders: 1,
                 minimize: PROD,
-                sourceMap: !PROD,
               },
             },
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = env => {
               loader: "css-loader",
               options: {
                 modules: true,
-                localIdentName: "[path]-[local]--[hash:base64:5]",
+                localIdentName: PROD ? "[hash:base64:5]"  : "[path]-[local]--[hash:base64:5]",
                 importLoaders: 1,
                 minimize: PROD,
               },


### PR DESCRIPTION
@miketaylr there is a bug with sourcemap and firefox in webpack. But at now css are inline, because I found a bug with extract plugin and the last version of webpack when I writed the webpack configuration. Css are inline and not extracted in a separate file. sourcemap are not usefull. In the futur if we decide to extract css we should active sourcemap option.

The second commit is just to reduced the size of `className` in production.