### PR TITLE
Fixes #154 - allowed new min* props in CommonFilters

### DIFF
--- a/src/components/Chart/CommonFilters.js
+++ b/src/components/Chart/CommonFilters.js
@@ -8,13 +8,14 @@ import PropTypes from "prop-types";
 import Input from "../Input";
 import { ObjectNested } from "../../libraries";
 
-const CommonFilters = ({ onChange, filters }) => {
+const CommonFilters = ({ onChange, filters, minFrom, minTo }) => {
   return (
     <React.Fragment>
       <Input
         type="date"
         name="from"
         placeholder="From"
+        min={minFrom}
         value={ObjectNested.get(filters, "from", "")}
         onChange={onChange}
       />
@@ -22,6 +23,7 @@ const CommonFilters = ({ onChange, filters }) => {
         type="date"
         name="to"
         placeholder="To"
+        min={minTo}
         value={ObjectNested.get(filters, "to", "")}
         onChange={onChange}
       />
@@ -35,6 +37,8 @@ CommonFilters.propTypes = {
     from: PropTypes.string,
     to: PropTypes.string,
   }),
+  minFrom: PropTypes.string,
+  minTo: PropTypes.string,
 };
 
 CommonFilters.defaultProps = {
@@ -42,6 +46,8 @@ CommonFilters.defaultProps = {
     from: "",
     to: "",
   },
+  minFrom: "",
+  minTo: "",
 };
 
 export default CommonFilters;

--- a/src/components/Chart/__tests__/CommonFilters-test.js
+++ b/src/components/Chart/__tests__/CommonFilters-test.js
@@ -11,7 +11,9 @@ import { CommonFilters } from "..";
 
 const obj = {
   from: "2018-11-22",
+  minFrom: "2018-11-22",
   to: "2018-12-22",
+  minTo: "2018-11-22",
 };
 
 it("renders CommonFilters: simulates change events", () => {

--- a/src/components/Chart/__tests__/__snapshots__/CommonFilters-test.js.snap
+++ b/src/components/Chart/__tests__/__snapshots__/CommonFilters-test.js.snap
@@ -4,6 +4,7 @@ exports[`renders CommonFilters default correctly 1`] = `
 Array [
   <input
     className="component"
+    min=""
     name="from"
     onChange={[Function]}
     placeholder="From"
@@ -12,6 +13,7 @@ Array [
   />,
   <input
     className="component"
+    min=""
     name="to"
     onChange={[Function]}
     placeholder="To"

--- a/src/constants/Charts.js
+++ b/src/constants/Charts.js
@@ -1,1 +1,7 @@
 export const CHART_LINE = "CHART_LINE";
+
+/**
+ * needstriage, needscontact, and sitewait) started collecting date
+ */
+
+export const TEMP_MIN_DATE = "2019-03-28";

--- a/src/containers/MetricsTemplate/__tests__/__snapshots__/MetricsTemplate-test.js.snap
+++ b/src/containers/MetricsTemplate/__tests__/__snapshots__/MetricsTemplate-test.js.snap
@@ -34,6 +34,7 @@ exports[`renders Component default correctly 1`] = `
       >
         <input
           className="component"
+          min=""
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -42,6 +43,7 @@ exports[`renders Component default correctly 1`] = `
         />
         <input
           className="component"
+          min=""
           name="to"
           onChange={[Function]}
           placeholder="To"
@@ -129,6 +131,7 @@ exports[`renders Component default correctly 2`] = `
       >
         <input
           className="component"
+          min=""
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -137,6 +140,7 @@ exports[`renders Component default correctly 2`] = `
         />
         <input
           className="component"
+          min=""
           name="to"
           onChange={[Function]}
           placeholder="To"

--- a/src/containers/NeedsContact/__tests__/__snapshots__/NeedsContact-test.js.snap
+++ b/src/containers/NeedsContact/__tests__/__snapshots__/NeedsContact-test.js.snap
@@ -34,6 +34,7 @@ exports[`renders Component default correctly 1`] = `
       >
         <input
           className="component"
+          min="2019-03-28"
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -42,6 +43,7 @@ exports[`renders Component default correctly 1`] = `
         />
         <input
           className="component"
+          min="2019-03-28"
           name="to"
           onChange={[Function]}
           placeholder="To"

--- a/src/containers/NeedsContact/index.js
+++ b/src/containers/NeedsContact/index.js
@@ -5,9 +5,15 @@
 import React from "react";
 
 import LineChart from "../../components/LineChart";
+import { CommonFilters } from "../../components/Chart";
 import MetricsTemplate from "../MetricsTemplate";
 import { ObjectNested } from "../../libraries";
-import { mostAndLeast, normalize } from "../../modules/Chart";
+import {
+  mostAndLeast,
+  normalize,
+  getTemporaryDefaultFilters,
+} from "../../modules/Chart";
+import { TEMP_MIN_DATE } from "../../constants/Charts";
 
 const handleData = data => {
   return {
@@ -23,6 +29,16 @@ const NeedsContact = () => {
       title={"Needs Contact Dashboard"}
       subtitle={"Tracking issue contact burndown rate"}
       normalizeData={handleData}
+      shouldRenderCommonFilters={false}
+      injectedFilters={getTemporaryDefaultFilters(TEMP_MIN_DATE)}
+      renderFilters={(handleChange, filters) => (
+        <CommonFilters
+          onChange={handleChange}
+          filters={filters}
+          minFrom={TEMP_MIN_DATE}
+          minTo={TEMP_MIN_DATE}
+        />
+      )}
       renderChart={data => (
         <LineChart
           title={"Open issues in needscontact milestone"}

--- a/src/containers/NeedsDiagnosis/__tests__/__snapshots__/NeedsDiagnosis-test.js.snap
+++ b/src/containers/NeedsDiagnosis/__tests__/__snapshots__/NeedsDiagnosis-test.js.snap
@@ -34,6 +34,7 @@ exports[`renders Component default correctly 1`] = `
       >
         <input
           className="component"
+          min=""
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -42,6 +43,7 @@ exports[`renders Component default correctly 1`] = `
         />
         <input
           className="component"
+          min=""
           name="to"
           onChange={[Function]}
           placeholder="To"

--- a/src/containers/NeedsTriage/__tests__/__snapshots__/NeedsTriage-test.js.snap
+++ b/src/containers/NeedsTriage/__tests__/__snapshots__/NeedsTriage-test.js.snap
@@ -34,6 +34,7 @@ exports[`renders Component default correctly 1`] = `
       >
         <input
           className="component"
+          min="2019-03-28"
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -42,6 +43,7 @@ exports[`renders Component default correctly 1`] = `
         />
         <input
           className="component"
+          min="2019-03-28"
           name="to"
           onChange={[Function]}
           placeholder="To"

--- a/src/containers/NeedsTriage/index.js
+++ b/src/containers/NeedsTriage/index.js
@@ -5,9 +5,15 @@
 import React from "react";
 
 import LineChart from "../../components/LineChart";
+import { CommonFilters } from "../../components/Chart";
 import MetricsTemplate from "../MetricsTemplate";
 import { ObjectNested } from "../../libraries";
-import { mostAndLeast, normalize } from "../../modules/Chart";
+import {
+  mostAndLeast,
+  normalize,
+  getTemporaryDefaultFilters,
+} from "../../modules/Chart";
+import { TEMP_MIN_DATE } from "../../constants/Charts";
 
 const handleData = data => {
   return {
@@ -23,6 +29,16 @@ const NeedsTriage = () => {
       title={"Needs triage dashboard"}
       subtitle={"Tracking issue triage burndown rate"}
       normalizeData={handleData}
+      shouldRenderCommonFilters={false}
+      injectedFilters={getTemporaryDefaultFilters(TEMP_MIN_DATE)}
+      renderFilters={(handleChange, filters) => (
+        <CommonFilters
+          onChange={handleChange}
+          filters={filters}
+          minFrom={TEMP_MIN_DATE}
+          minTo={TEMP_MIN_DATE}
+        />
+      )}
       renderChart={data => (
         <LineChart
           title={"Open issues in needstriage milestone"}

--- a/src/containers/SiteWait/__tests__/__snapshots__/SiteWait-test.js.snap
+++ b/src/containers/SiteWait/__tests__/__snapshots__/SiteWait-test.js.snap
@@ -34,6 +34,7 @@ exports[`renders Component default correctly 1`] = `
       >
         <input
           className="component"
+          min="2019-03-28"
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -42,6 +43,7 @@ exports[`renders Component default correctly 1`] = `
         />
         <input
           className="component"
+          min="2019-03-28"
           name="to"
           onChange={[Function]}
           placeholder="To"

--- a/src/containers/SiteWait/index.js
+++ b/src/containers/SiteWait/index.js
@@ -5,9 +5,15 @@
 import React from "react";
 
 import LineChart from "../../components/LineChart";
+import { CommonFilters } from "../../components/Chart";
 import MetricsTemplate from "../MetricsTemplate";
 import { ObjectNested } from "../../libraries";
-import { mostAndLeast, normalize } from "../../modules/Chart";
+import {
+  mostAndLeast,
+  normalize,
+  getTemporaryDefaultFilters,
+} from "../../modules/Chart";
+import { TEMP_MIN_DATE } from "../../constants/Charts";
 
 const handleData = data => {
   return {
@@ -23,6 +29,16 @@ const SiteWait = () => {
       title={"Site Wait Dashboard"}
       subtitle={"Tracking issue sitewait burndown rate"}
       normalizeData={handleData}
+      shouldRenderCommonFilters={false}
+      injectedFilters={getTemporaryDefaultFilters(TEMP_MIN_DATE)}
+      renderFilters={(handleChange, filters) => (
+        <CommonFilters
+          onChange={handleChange}
+          filters={filters}
+          minFrom={TEMP_MIN_DATE}
+          minTo={TEMP_MIN_DATE}
+        />
+      )}
       renderChart={data => (
         <LineChart
           title={"Open issues in sitewait milestone"}

--- a/src/containers/WeeklyReports/__tests__/__snapshots__/WeeklyReports-test.js.snap
+++ b/src/containers/WeeklyReports/__tests__/__snapshots__/WeeklyReports-test.js.snap
@@ -34,6 +34,7 @@ exports[`renders Component default correctly 1`] = `
       >
         <input
           className="component"
+          min=""
           name="from"
           onChange={[Function]}
           placeholder="From"
@@ -42,6 +43,7 @@ exports[`renders Component default correctly 1`] = `
         />
         <input
           className="component"
+          min=""
           name="to"
           onChange={[Function]}
           placeholder="To"

--- a/src/layouts/__tests__/__snapshots__/index-test.js.snap
+++ b/src/layouts/__tests__/__snapshots__/index-test.js.snap
@@ -294,6 +294,7 @@ exports[`renders Component default correctly 1`] = `
           >
             <input
               className="component"
+              min=""
               name="from"
               onChange={[Function]}
               placeholder="From"
@@ -302,6 +303,7 @@ exports[`renders Component default correctly 1`] = `
             />
             <input
               className="component"
+              min=""
               name="to"
               onChange={[Function]}
               placeholder="To"

--- a/src/layouts/__tests__/__snapshots__/matchMedia-test.js.snap
+++ b/src/layouts/__tests__/__snapshots__/matchMedia-test.js.snap
@@ -294,6 +294,7 @@ exports[`renders Component matchMedia return true 1`] = `
           >
             <input
               className="component"
+              min=""
               name="from"
               onChange={[Function]}
               placeholder="From"
@@ -302,6 +303,7 @@ exports[`renders Component matchMedia return true 1`] = `
             />
             <input
               className="component"
+              min=""
               name="to"
               onChange={[Function]}
               placeholder="To"

--- a/src/modules/Chart/index.js
+++ b/src/modules/Chart/index.js
@@ -91,3 +91,22 @@ export const mostAndLeast = (stats = {}) => {
     };
   }, obj);
 };
+
+/**
+ * needstriage, needscontact, and sitewait) started collecting date
+ * Default Filters take car about min date
+ * @param {string} minDate
+ * @return {object}
+ */
+export const getTemporaryDefaultFilters = minDate => {
+  const today = dayjs();
+  const oneMonthBefore = today.subtract(1, "month");
+  const to = today.format("YYYY-MM-DD");
+  const from = oneMonthBefore.isBefore(dayjs(minDate))
+    ? minDate
+    : oneMonthBefore.format("YYYY-MM-DD");
+  return {
+    from,
+    to,
+  };
+};


### PR DESCRIPTION
Adding a `min` attribute in `NeedsTriage` `needsContact` and `siteWait` to take account about https://github.com/webcompat/webcompat-metrics-client/issues/154#issuecomment-478004468 on the `<input type="date" />` `from` and `to`.

I also added a function to define default Filters with min date (`2019/03/28`) in param.

@miketaylr for JavaScript 

@laghee for the logic 

<3 