### PR TITLE
fixes #119 - added env const  for connecting server

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,0 +1,2 @@
+API_BASE_URL=https://webcompat-metrics.herokuapp.com/data
+WEBCOMPAT_BASE_URL=https://webcompat.com/api/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+API_BASE_URL=https://webcompat-metrics.herokuapp.com/data
+WEBCOMPAT_BASE_URL=https://webcompat.com/api/
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Environment variables
 
 You can create a .env file (or copy .env.example) and modify variables, make sure variables are all set.
 
-By default `.env.defaults` is loading and injected throught the webpack configuration.
+By default `.env.defaults` is loaded and injected through the webpack configuration.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ npm run start:dev
 # Go to http://localhost:3001
 ```
 
+### Configuration
+Environment variables
+
+You can create a .env file (or copy .env.example) and modify variables, make sure variables are all set.
+
+By default `.env.defaults` is loading and injected throught the webpack configuration.
+
 ### Testing
 
 For testing DOM, React component, and others JavaScript, we use [Jest], [Enzyme] and [Sinon.JS].

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "copy-webpack-plugin": "^5.0.2",
     "css-loader": "^1.0.0",
+    "dotenv-webpack": "^1.7.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "eslint": "^5.15.3",

--- a/src/constants/Api.js
+++ b/src/constants/Api.js
@@ -19,7 +19,3 @@ export const CALLBACK_API = {
   onError: payload => {},
   onFinish: (payload, isError) => {},
 };
-
-/* base API url */
-export const API_BASE_URL = "https://webcompat-metrics.herokuapp.com/data";
-export const WEBCOMPAT_BASE_URL = "https://webcompat.com/api/";

--- a/src/constants/EndPoints.js
+++ b/src/constants/EndPoints.js
@@ -4,7 +4,8 @@
 
 import { Router } from "../libraries";
 
-import { API_BASE_URL, WEBCOMPAT_BASE_URL } from "./Api";
+const WEBCOMPAT_BASE_URL = process.env.WEBCOMPAT_BASE_URL;
+const API_BASE_URL = process.env.API_BASE_URL;
 
 /*
  * Ochazuke endPoints

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+const Dotenv = require("dotenv-webpack");
 
 const StylesVariables = require("./src/constants/StylesVariables");
 
@@ -104,6 +105,11 @@ module.exports = env => {
       new FaviconsWebpackPlugin({
         logo: path.resolve(LOGO_DIRECTORY, "logo.png"),
         inject: true,
+      }),
+      new Dotenv({
+        safe: true,
+        systemvars: true,
+        defaults: true,
       }),
     ],
     devServer: {


### PR DESCRIPTION
@karlcow we can now choose on which server we want to connect on. By default when we deploy the app the `.env.defaults` is loading by default, but you can create `.env` file and definied yourself the servers.