### PR TITLE
issue #400 - fixes the label type spelling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
   reviewers:
   - magsout
   labels:
-  - "type : dependencies"
+  - "type: dependencies"


### PR DESCRIPTION
Fixes #400
The label comment for dependencies was spelled wrongly. 